### PR TITLE
Fix firewall status message typo

### DIFF
--- a/scripts/firewall.sh
+++ b/scripts/firewall.sh
@@ -19,7 +19,7 @@ if ! systemctl is-enabled firewalld &> /dev/null; then
   echo "firewalld is installed but not enabled to start at boot"
   systemctl enable firewalld
 fi
-echo "firewalld is avaible, enabled at boot, and running"
+echo "firewalld is available, enabled at boot, and running"
 echo "configuring ports on the firewall"
 
 # Add the port permanently


### PR DESCRIPTION
## Summary
- fix typo in `firewall.sh` status message

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6865a14acb2083208516e6ef94afecad