### PR TITLE
Fix MariaDB comment typo

### DIFF
--- a/scripts/mariadb.sh
+++ b/scripts/mariadb.sh
@@ -3,7 +3,7 @@
 # Absolute path to config folder in script directory
 CONFIG_PATH="$1"
 
-# user account and password for MaraiDB resolve user
+# user account and password for MariaDB resolve user
 RESOLVE_USER="$2"
 RESOLVE_PASS="$3"
 


### PR DESCRIPTION
## Summary
- fix a typo in scripts/mariadb.sh comment to correctly spell 'MariaDB'

## Testing
- `grep -n MariaDB scripts/mariadb.sh`


------
https://chatgpt.com/codex/tasks/task_e_6865a15203988320a932134e8005608a