### PR TITLE
Fix variable mismatch for .gov.tar.gz check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ done
 mkdir -p dist
 
 # Check if a gov.tar.gz file exists
-GZ_FILES=$(find dist -maxdepth 1 -type f -name "*.gov.tar.gz" | head -n 1)
+GZ_FILE=$(find dist -maxdepth 1 -type f -name "*.gov.tar.gz" | head -n 1)
 
 if [[ -f "$GZ_FILE" ]]; then
   echo "Found existing Resolve Action Pro Gov Edition installation file" 


### PR DESCRIPTION
## Summary
- use `GZ_FILE` variable consistently when locating existing `.gov.tar.gz` files

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6865a14e6094832091ee8c12e9e6d411